### PR TITLE
style: Ajuste opacidad de section-title para mejorar legibilidad

### DIFF
--- a/global.css
+++ b/global.css
@@ -137,7 +137,7 @@ body {
     var(--3-accent),
     var(--2-secondary)
   );
-  opacity: 0.15;
+  opacity: 0.5;
   text-align: center;
 }
 /* sections */


### PR DESCRIPTION
## Descripción del Cambio
 - Este PR ajusta la opacidad de los títulos de sección (section-title) para mejorar su legibilidad. Anteriormente, la opacidad era demasiado baja, lo que dificultaba la lectura de los títulos. Ahora se ha incrementado la opacidad a 0.5, lo que mejora la visibilidad sin comprometer el diseño original.

## Motivación y Contexto
- Este cambio soluciona un problema de legibilidad reportado en los títulos de sección debido a su baja opacidad. Con este ajuste, se consigue un mejor equilibrio entre la estética y la funcionalidad, asegurando que los títulos sean más fáciles de leer para todos los usuarios.

## Cambios Realizados
- Incremento de la opacidad de los títulos de sección a 0.5 en los estilos CSS.
- Verificación de que la modificación no afecta la consistencia del diseño en otras partes de la interfaz.

Fixes: #1

## Actualmente

![image](https://github.com/user-attachments/assets/f643047a-c3b1-497b-ae15-e29cb9729c5a)

## Propuesta de cambio

![image](https://github.com/user-attachments/assets/85834be4-8405-4833-a2af-ad62c3396025)
